### PR TITLE
Updated Akka version to 2.6.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 scalaBinaryVersion = 2.13
-akkaTypedVersion = 2.6.20
+akkaTypedVersion = 2.6.21
 akkaHttpVersion = 10.2.10
 junitVersion = 4.13.2
 testContainersVersion = 1.17.6


### PR DESCRIPTION
Updated Akka version to 2.6.21 - the most recent one from the free Akka versions. 